### PR TITLE
(SIMP-432) Backuppc fails to install

### DIFF
--- a/build/pupmod-backuppc.spec
+++ b/build/pupmod-backuppc.spec
@@ -35,7 +35,7 @@ for dir in $dirs; do
 done
 
 mkdir -p %{buildroot}/usr/share/simp/tests/modules/backuppc
-cp README %{buildroot}/%{prefix}/backuppc
+cp README.md %{buildroot}/%{prefix}/backuppc
 
 %clean
 [ "%{buildroot}" != "/" ] && rm -rf %{buildroot}


### PR DESCRIPTION
In SIMP-399, the original README was merged with the new README.md and
on line 38 of the build script (build/pupmod-backuppc.spec), it tries to
install README. It cannot be found, so the installation fails.

It will now install README.md.

SIMP-432 #close
